### PR TITLE
fix JSONBaseProvide.isConnected

### DIFF
--- a/web3/providers/base.py
+++ b/web3/providers/base.py
@@ -54,8 +54,7 @@ class JSONBaseProvider(BaseProvider):
 
     def isConnected(self):
         try:
-            response_raw = self.make_request('web3_clientVersion', [])
-            response = json.loads(force_text(response_raw))
+            response = self.make_request('web3_clientVersion', [])
         except IOError:
             return False
         else:


### PR DESCRIPTION
### What was wrong?
After https://github.com/pipermerriam/web3.py/commit/699a775411062bfd748a38565c2de3703d757b30, JSONBaseProvide.isConnected is broken because of doing json.loads on dict object


### How was it fixed?
remove the superfluous json.loads in isConnected


#### Cute Animal Picture

![Cute animal picture]()
